### PR TITLE
Enhance Design API for near-square to accept length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ non-exhaustive list of the possible categories issues could fall in:
 
 ## Current version 
 
+### Enhances 
+
+* [Issue 81](https://github.com/j-c-cook/ghedt/issues/81) - The `near-square` design option in the `Design` object now requires the user to specify a land length which computes a maximum number of boreholes rather. This functionality replaces a hard-coded 32x32 maximum. 
+
 ### Fixes
 
 * [Issue 79](https://github.com/j-c-cook/ghedt/issues/79) - Fixes the possibility for the peak load analysis tool to determine a negative peak load duration when the first month contains no load.  

--- a/ghedt/design.py
+++ b/ghedt/design.py
@@ -90,14 +90,14 @@ class Design:
                 self.coordinates_domain_nested, self.V_flow,
                 self.borehole, self.bhe_object, self.fluid, self.pipe,
                 self.grout, self.soil, self.sim_params,
-                self.hourly_extraction_ground_loads, flow=self.flow, disp=False)
+                self.hourly_extraction_ground_loads, flow=self.flow, disp=disp)
         # Find bi-zoned rectangle
         elif self.routine == 'bi-zoned':
             bisection_search = dt.search_routines.BisectionZD(
                 self.coordinates_domain_nested, self.V_flow, self.borehole,
                 self.bhe_object, self.fluid, self.pipe, self.grout, self.soil,
                 self.sim_params, self.hourly_extraction_ground_loads,
-                flow=self.flow, disp=False)
+                flow=self.flow, disp=disp)
         else:
             raise ValueError('The requested routine is not available. '
                              'The currently available routines are: '

--- a/ghedt/design.py
+++ b/ghedt/design.py
@@ -4,6 +4,7 @@
 import ghedt as dt
 import ghedt.peak_load_analysis_tool as plat
 import pygfunction as gt
+import numpy as np
 
 
 # Common design interface
@@ -36,10 +37,17 @@ class Design:
         if routine in available_routines:
             # If a near-square design routine is requested, then we go from a
             # 1x1 to 32x32 at the B-spacing
+            # The lower end of the near-square routine is always 1 borehole.
+            # There would never be a time that a user would __need__ to give a
+            # different lower range. The upper number of boreholes range is
+            # calculated based on the spacing and length provided.
             if routine == 'near-square':
+                number_of_boreholes = \
+                    dt.utilities.number_of_boreholes(
+                        gc.length, gc.B, func=np.floor)
                 self.coordinates_domain = \
                     dt.domains.square_and_near_square(
-                        1, 32, self.geometric_constraints.B)
+                        1, number_of_boreholes, self.geometric_constraints.B)
             elif routine == 'rectangle':
                 self.coordinates_domain = dt.domains.rectangular(
                     gc.length, gc.width, gc.B_min, gc.B_max_x, disp=False
@@ -59,6 +67,9 @@ class Design:
         self.flow = flow
 
     def find_design(self, disp=False):
+        if disp:
+            title = 'Find {}...'.format(self.routine)
+            print(title + '\n' + len(title) * '=')
         # Find near-square
         if self.routine == 'near-square':
             bisection_search = dt.search_routines.Bisection1D(

--- a/ghedt/examples/Design/find_bi_rectangle.py
+++ b/ghedt/examples/Design/find_bi_rectangle.py
@@ -130,15 +130,16 @@ def main():
     B_max_x = 10.  # m
     B_max_y = 12.  # m
 
-    # Geometric constraints for the `find_rectangle` routine
-    # Required geometric constraints for the uniform rectangle design: length,
-    # width, B_min, B_max
+    """ Geometric constraints for the `find_rectangle` routine.
+    Required geometric constraints for the uniform rectangle design: 
+      - length
+      - width
+      - B_min
+      - B_max
+    """
     geometric_constraints = dt.media.GeometricConstraints(
         length=length, width=width, B_min=B_min, B_max_x=B_max_x,
         B_max_y=B_max_y)
-
-    title = 'Find bi-rectangle...'
-    print(title + '\n' + len(title) * '=')
 
     # Single U-tube
     # -------------
@@ -149,7 +150,7 @@ def main():
 
     # Find a constrained rectangular design for a single U-tube and size it.
     tic = clock()
-    bisection_search = design_single_u_tube.find_design()
+    bisection_search = design_single_u_tube.find_design(disp=True)
     bisection_search.ghe.compute_g_functions()
     bisection_search.ghe.size(method='hybrid')
     toc = clock()

--- a/ghedt/examples/Design/find_bi_zoned_rectangle.py
+++ b/ghedt/examples/Design/find_bi_zoned_rectangle.py
@@ -129,15 +129,16 @@ def main():
     B_max_x = 10.  # m
     B_max_y = 12.  # m
 
-    # Geometric constraints for the `find_rectangle` routine
-    # Required geometric constraints for the uniform rectangle design: length,
-    # width, B_min, B_max
+    """ Geometric constraints for the `bi-zoned` routine.
+    Required geometric constraints for the bi-zoned design: 
+      - length
+      - width
+      - B_min
+      - B_max
+    """
     geometric_constraints = dt.media.GeometricConstraints(
         length=length, width=width, B_min=B_min, B_max_x=B_max_x,
         B_max_y=B_max_y)
-
-    title = 'Find bi-zoned rectangle'
-    print(title + '\n' + len(title) * '=')
 
     # Single U-tube
     # -------------
@@ -148,7 +149,7 @@ def main():
 
     # Find a constrained rectangular design for a single U-tube and size it.
     tic = clock()
-    bisection_search = design_single_u_tube.find_design()
+    bisection_search = design_single_u_tube.find_design(disp=True)
     bisection_search.ghe.compute_g_functions()
     bisection_search.ghe.size(method='hybrid')
     toc = clock()

--- a/ghedt/examples/Design/find_near_square.py
+++ b/ghedt/examples/Design/find_near_square.py
@@ -124,8 +124,8 @@ def main():
 
     """ Geometric constraints for the `near-square` routine.
     Required geometric constraints for the uniform rectangle design:
-    - B
-    - length
+      - B
+      - length
     """
     # B is already defined above
     number_of_boreholes = 32

--- a/ghedt/examples/Design/find_near_square.py
+++ b/ghedt/examples/Design/find_near_square.py
@@ -122,12 +122,15 @@ def main():
     hourly_extraction_ground_loads: list = \
         hourly_extraction[list(hourly_extraction.keys())[0]]
 
-    # Geometric constraints for the `near-square` routine
-    # Required geometric constraints for the uniform rectangle design: B
-    geometric_constraints = dt.media.GeometricConstraints(B=B)
-
-    title = 'Find near square...'
-    print(title + '\n' + len(title) * '=')
+    """ Geometric constraints for the `near-square` routine.
+    Required geometric constraints for the uniform rectangle design:
+    - B
+    - length
+    """
+    # B is already defined above
+    number_of_boreholes = 32
+    length = dt.utilities.length_of_side(number_of_boreholes, B)
+    geometric_constraints = dt.media.GeometricConstraints(B=B, length=length)
 
     # Single U-tube
     # -------------
@@ -138,7 +141,7 @@ def main():
 
     # Find the near-square design for a single U-tube and size it.
     tic = clock()
-    bisection_search = design_single_u_tube.find_design()
+    bisection_search = design_single_u_tube.find_design(disp=True)
     bisection_search.ghe.compute_g_functions()
     bisection_search.ghe.size(method='hybrid')
     toc = clock()

--- a/ghedt/examples/Design/find_rectangle.py
+++ b/ghedt/examples/Design/find_rectangle.py
@@ -130,9 +130,13 @@ def main():
     B_min = 3.  # m
     B_max = 10.  # m
 
-    # Geometric constraints for the `find_rectangle` routine
-    # Required geometric constraints for the uniform rectangle design: length,
-    # width, B_min, B_max
+    """ Geometric constraints for the `find_rectangle` routine.
+    Required geometric constraints for the uniform rectangle design: 
+      - length
+      - width 
+      - B_min
+      - B_max
+    """
     geometric_constraints = dt.media.GeometricConstraints(
         length=length, width=width, B_min=B_min, B_max_x=B_max)
 

--- a/ghedt/media.py
+++ b/ghedt/media.py
@@ -26,6 +26,7 @@ class GeometricConstraints:
         # The required instances for the near-square design is self.B
         if method == 'near-square':
             assert self.B is not None
+            assert self.length is not None
         elif method == 'rectangle':
             assert self.width is not None
             assert self.length is not None

--- a/ghedt/search_routines.py
+++ b/ghedt/search_routines.py
@@ -218,6 +218,9 @@ class Bisection2D(Bisection1D):
                  sim_params: plat.media.SimulationParameters,
                  hourly_extraction_ground_loads: list, flow: str = 'borehole',
                  max_iter=15, disp=False):
+        if disp:
+            print('Note: This routine requires a nested bisection search.')
+
         # Get a coordinates domain for initialization
         coordinates_domain = coordinates_domain_nested[0]
         Bisection1D.__init__(
@@ -261,6 +264,10 @@ class BisectionZD(Bisection1D):
                  sim_params: plat.media.SimulationParameters,
                  hourly_extraction_ground_loads: list, flow: str = 'borehole',
                  max_iter=15, disp=False):
+        if disp:
+            print('Note: This design routine currently requires several '
+                  'bisection searches.')
+
         # Get a coordinates domain for initialization
         coordinates_domain = coordinates_domain_nested[0]
         Bisection1D.__init__(

--- a/ghedt/search_routines.py
+++ b/ghedt/search_routines.py
@@ -102,8 +102,10 @@ class Bisection1D:
         max_HP_EFT, min_HP_EFT = self.ghe.simulate()
         T_excess = self.ghe.cost(max_HP_EFT, min_HP_EFT)
 
-        if self.disp:
-            print('Min EFT: {}\nMax EFT: {}'.format(min_HP_EFT, max_HP_EFT))
+        # This is more of a debugging statement. May remove it in the future.
+        # Perhaps there becomes a debug: bool option in the API.
+        # if self.disp:
+        #     print('Min EFT: {}\nMax EFT: {}'.format(min_HP_EFT, max_HP_EFT))
 
         return T_excess
 
@@ -111,7 +113,8 @@ class Bisection1D:
 
         xL_idx = 0
         xR_idx = len(self.coordinates_domain) - 1
-        # Do some initial checks before searching
+        if self.disp:
+            print('Do some initial checks before searching.')
         # Get the lowest possible excess temperature from minimum height at the
         # smallest location in the domain
         T_0_lower = self.calculate_excess(self.coordinates_domain[xL_idx],
@@ -126,13 +129,15 @@ class Bisection1D:
         self.calculated_temperatures[xL_idx] = T_0_upper
         self.calculated_temperatures[xR_idx] = T_m1
 
-        if check_bracket(sign(T_0_lower), sign(T_0_upper), disp=self.disp):
-            # Size between min and max of lower bound in domain
+        if check_bracket(sign(T_0_lower), sign(T_0_upper)):
+            if self.disp:
+                print('Size between min and max of lower bound in domain.')
             self.initialize_ghe(self.coordinates_domain[0],
                                 self.sim_params.max_Height)
             return 0, self.coordinates_domain[0]
-        elif check_bracket(sign(T_0_upper), sign(T_m1), disp=self.disp):
-            # Do the integer bisection search routine
+        elif check_bracket(sign(T_0_upper), sign(T_m1)):
+            if self.disp:
+                print('Perform the integer bisection search routine.')
             pass
         else:
             # This domain does not bracked the solution

--- a/ghedt/utilities.py
+++ b/ghedt/utilities.py
@@ -13,6 +13,7 @@ import numpy as np
 import json
 from matplotlib.ticker import Locator
 import pickle
+import warnings
 
 
 # Time functions
@@ -54,17 +55,17 @@ def polygonal_area(corners):
     area = abs(area) / 2.0
     return area
 
-
-def set_shank(configuration: str, rb: float, r_in: float, r_out: float):
-    raise ValueError('This function is incomplete.')
-    if configuration == 'A':
-        a = 1
-    elif configuration == 'B':
-        a = 1
-    elif configuration == 'C':
-        a = 1
-    else:
-        raise ValueError('Only configurations A, B, or C are valid.')
+# TODO: Add `set_shank` functionality to utilities.py
+# def set_shank(configuration: str, rb: float, r_in: float, r_out: float):
+#     raise ValueError('This function is incomplete.')
+#     if configuration == 'A':
+#         a = 1
+#     elif configuration == 'B':
+#         a = 1
+#     elif configuration == 'C':
+#         a = 1
+#     else:
+#         raise ValueError('Only configurations A, B, or C are valid.')
 
 
 def make_rectangle_perimeter(length_x, length_y, origin=(0, 0)):
@@ -76,6 +77,21 @@ def make_rectangle_perimeter(length_x, length_y, origin=(0, 0)):
          [origin_x + length_x, origin_y + length_y],
          [origin_x, origin_y + length_y]]
     return rectangle_perimeter
+
+
+def number_of_boreholes(length, B, func=np.ceil):
+    N = func(length / B) + 1
+    return int(N)
+
+
+def length_of_side(N, B):
+    L = (N - 1) * B
+    return L
+
+
+def spacing_along_length(L, N):
+    B = L / (N - 1)
+    return B
 
 
 # Design oriented functions
@@ -90,19 +106,18 @@ def sign(x: float) -> int:
     return int(abs(x) / x)
 
 
-def check_bracket(sign_xL, sign_xR, disp=False) -> bool:
+def check_bracket(sign_xL, sign_xR, disp=None) -> bool:
+    if disp is not None:
+        warnings.warn('The disp option in check_bracket will be removed in '
+                      'the ghedt 0.2 release.')
     if sign_xL < 0 < sign_xR:
-        if disp:
-            print('Bracketed the root')
+        # Bracketed the root
         return True
     elif sign_xR < 0 < sign_xL:
-        if disp:
-            print('Bracketed the root')
+        # Bracketed the root
         return True
     else:
-        if disp:
-            print('The root has not been bracketed, '
-                  'this method will return false.')
+        # The root has not been bracketed, this method will return false.
         return False
 
 

--- a/tests/test_design.py
+++ b/tests/test_design.py
@@ -137,7 +137,10 @@ class TestNearSquare(unittest.TestCase, DesignBase):
         # Geometric constraints for the `near-square` routine
         # Required geometric constraints for the uniform rectangle design: B
         B = 5.  # Borehole spacing (m)
-        self.geometric_constraints = dt.media.GeometricConstraints(B=B)
+        number_of_boreholes = 32
+        length = dt.utilities.length_of_side(number_of_boreholes, B)
+        self.geometric_constraints = \
+            dt.media.GeometricConstraints(B=B, length=length)
 
     def test_design_selection(self):
         # Single U-tube


### PR DESCRIPTION
- Add helper functions to `utilities.py` to compute L, B, or number of
  boreholes.
- Comment unfinished `set_shank()` function in `utilities.py` and add
  a TODO above it. (This requires a new issue.)
- Add assertion to `check_inputs` in `media.py` for the `near-square`
  selection that ensures `length` is not None.
- Add new near-square functionality to `Design`.
- Improve disp=True option for Design object.
- Update `find_near_square.py` example file.
- Document the changes in the log.

closes #81