### PR TITLE
Update monthly peak loads based on two-day peak load period.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 Create_Branch.sh
 ghedt/ghedt-examples/
+
+# pycharm
+.idea/
+
+*.egg-info/
+*__pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,12 @@ non-exhaustive list of the possible categories issues could fall in:
 
 ### Enhances 
 
-* [Issue 81](https://github.com/j-c-cook/ghedt/issues/81) - The `near-square` design option in the `Design` object now requires the user to specify a land length which computes a maximum number of boreholes rather. This functionality replaces a hard-coded 32x32 maximum. 
+* [Issue 81](https://github.com/j-c-cook/ghedt/issues/81) - The `near-square` design option in the `Design` object now requires the user to specify a land length which computes a maximum number of boreholes rather. This functionality replaces a hard-coded 32x32 maximum.
 
 ### Fixes
 
-* [Issue 79](https://github.com/j-c-cook/ghedt/issues/79) - Fixes the possibility for the peak load analysis tool to determine a negative peak load duration when the first month contains no load.  
+* [Issue 79](https://github.com/j-c-cook/ghedt/issues/79) - Fixes the possibility for the peak load analysis tool to determine a negative peak load duration when the first month contains no load.
+* [Issue 84](https://github.com/j-c-cook/ghedt/issues/84) - Fixes the two-day peak simulation to utilize the peak load from either the 48-hour profile or the current month.
 
 ## Version 0.1
 

--- a/ghedt/peak_load_analysis_tool/ground_loads.py
+++ b/ghedt/peak_load_analysis_tool/ground_loads.py
@@ -456,13 +456,16 @@ class HybridLoad:
             current_two_day_cl_load = \
                 [0.] + self.two_day_hourly_peak_cl_loads[i]
 
+            # Ensure the peak load for the two-day load profile is the same or
+            # greater than the monthly peak load. This check is done in case
+            # the previous month contains a higher load than the current month.
+            load_diff = \
+                self.monthly_peak_cl[i] - max(current_two_day_cl_load)
             # monthly peak cooling load (or heat rejection) in kW
-            # check if the max monthly load is the same as the max load in the two-day data
-            if abs(self.monthly_peak_cl[i] - max(current_two_day_cl_load)) > 0.1:
-                # loads do not match with tolerance - update peak load accordingly
-                self.monthly_peak_cl[i] = max(current_two_day_cl_load)
-
-            current_month_peak_cl = self.monthly_peak_cl[i]
+            if load_diff > 0.0:
+                current_month_peak_cl = self.monthly_peak_cl[i]
+            else:
+                current_month_peak_cl = max(current_two_day_cl_load)
 
             # monthly average cooling load (or heat rejection) in kW
             current_month_avg_cl = self.monthly_avg_cl[i]
@@ -483,13 +486,16 @@ class HybridLoad:
             current_two_day_hl_load = \
                 [0.] + self.two_day_hourly_peak_hl_loads[i]
 
-            # monthly peak heating load (or heat extraction) in kW
-            # check if the max monthly load is the same as the max load in the two-day data
-            if abs(self.monthly_peak_hl[i] - max(current_two_day_hl_load)) > 0.1:
-                # loads do not match with tolerance - update peak load accordingly
-                self.monthly_peak_hl[i] = max(current_two_day_hl_load)
-
-            current_month_peak_hl = self.monthly_peak_hl[i]
+            # Ensure the peak load for the two-day load profile is the same or
+            # greater than the monthly peak load. This check is done in case
+            # the previous month contains a higher load than the current month.
+            load_diff = \
+                self.monthly_peak_hl[i] - max(current_two_day_hl_load)
+            # monthly peak cooling load (or heat rejection) in kW
+            if load_diff > 0.0:
+                current_month_peak_hl = self.monthly_peak_hl[i]
+            else:
+                current_month_peak_hl = max(current_two_day_hl_load)
 
             # monthly average heating load (or heat extraction) in kW
             current_month_avg_hl = self.monthly_avg_hl[i]

--- a/ghedt/peak_load_analysis_tool/ground_loads.py
+++ b/ghedt/peak_load_analysis_tool/ground_loads.py
@@ -259,7 +259,7 @@ class HybridLoad:
             if l_hour >= 0.0:
                 # Heat is extracted from ground when > 0
                 hourly_extraction_loads[i] = l_hour / scale
-            elif l_hour < 0.0:
+            else:
                 # Heat is rejected to ground when < 0
                 hourly_rejection_loads[i] = l_hour / -scale
 
@@ -455,8 +455,15 @@ class HybridLoad:
             # two day cooling loads (or heat rejection) in kWh
             current_two_day_cl_load = \
                 [0.] + self.two_day_hourly_peak_cl_loads[i]
+
             # monthly peak cooling load (or heat rejection) in kW
+            # check if the max monthly load is the same as the max load in the two-day data
+            if abs(self.monthly_peak_cl[i] - max(current_two_day_cl_load)) > 0.1:
+                # loads do not match with tolerance - update peak load accordingly
+                self.monthly_peak_cl[i] = max(current_two_day_cl_load)
+
             current_month_peak_cl = self.monthly_peak_cl[i]
+
             # monthly average cooling load (or heat rejection) in kW
             current_month_avg_cl = self.monthly_avg_cl[i]
 
@@ -475,8 +482,15 @@ class HybridLoad:
             # two day heating loads (or heat extraction) in kWh
             current_two_day_hl_load = \
                 [0.] + self.two_day_hourly_peak_hl_loads[i]
+
             # monthly peak heating load (or heat extraction) in kW
+            # check if the max monthly load is the same as the max load in the two-day data
+            if abs(self.monthly_peak_hl[i] - max(current_two_day_hl_load)) > 0.1:
+                # loads do not match with tolerance - update peak load accordingly
+                self.monthly_peak_hl[i] = max(current_two_day_hl_load)
+
             current_month_peak_hl = self.monthly_peak_hl[i]
+
             # monthly average heating load (or heat extraction) in kW
             current_month_avg_hl = self.monthly_avg_hl[i]
 


### PR DESCRIPTION
The issue addressed in this PR has to do with the peak load analysis in particular. If a peak load is found to be on the first day of the month, then the 48-hour load profile created takes the previous months last day and the first day of the current month. An issue can arise when the current months maximum load is less than the maximum load found in the last day of the previous month. The result is that the two-day nominal load profile could produce a greater temperature difference than the peak load profile does. 

closes #84
closes #88 