### PR TITLE
Remove passing single u-tube instance through `calc_sts_g_functions`

### DIFF
--- a/ghedt/ground_heat_exchangers.py
+++ b/ghedt/ground_heat_exchangers.py
@@ -38,7 +38,7 @@ class BaseGHE:
         # Radial numerical short time step
         self.radial_numerical = \
             plat.radial_numerical_borehole.RadialNumericalBH(self.bhe_eq)
-        self.radial_numerical.calc_sts_g_functions(self.bhe_eq)
+        self.radial_numerical.calc_sts_g_functions()
 
         # GFunction object
         self.GFunction = GFunction
@@ -291,7 +291,7 @@ class GHE(BaseGHE):
         # Solve for equivalent single U-tube
         self.bhe_eq = plat.equivalance.compute_equivalent(self.bhe)
         # Update short time step object with equivalent single u-tube
-        self.radial_numerical.calc_sts_g_functions(self.bhe_eq)
+        self.radial_numerical.calc_sts_g_functions()
         # Combine the short and long-term g-functions. The long term g-function
         # is interpolated for specific B/H and rb/H values.
         g = self.grab_g_function(B_over_H)

--- a/ghedt/peak_load_analysis_tool/radial_numerical_borehole.py
+++ b/ghedt/peak_load_analysis_tool/radial_numerical_borehole.py
@@ -258,10 +258,7 @@ class RadialNumericalBH(object):
                 dtype=self.dtype)
         cell_summation += num_soil_cells
 
-    def calc_sts_g_functions(
-            self, single_u_tube, final_time=None, calculate_at_bh_wall=False) -> tuple:
-
-        self.__init__(single_u_tube)
+    def calc_sts_g_functions(self, final_time=None, calculate_at_bh_wall=False) -> tuple:
 
         Rb = self.single_u_tube.compute_effective_borehole_resistance()
 


### PR DESCRIPTION
The single u-tube instance that was being passed through the `calc_sts_g_functions` method is unused. This eliminates it in lieu of the version passed through the ctor.